### PR TITLE
Feature/save crash details

### DIFF
--- a/lib/AppKit/AppKit.h
+++ b/lib/AppKit/AppKit.h
@@ -28,6 +28,7 @@
 #include <Logger.h>
 #include <LispDevice.h>
 #include <LispPrimitives.h>
+#include <CrashStorage.h>
 
 namespace uniot
 {
@@ -39,13 +40,15 @@ public:
           auto arr = info.putArray("primitives");
           getLisp().serializeNamesOfPrimitives(arr.get());
           arr->closeArray();
-        }),
-        mLispButton(pinBtn, activeLevelBtn, 30), mNetworkDevice(credentials, pinBtn, activeLevelBtn, pinLed)
+        })
+      , mLispButton(pinBtn, activeLevelBtn, 30), mNetworkDevice(credentials, pinBtn, activeLevelBtn, pinLed)
+      , mCrashStorage("crash_dump.txt")
   {
     _initMqtt();
     _initTasks();
     _initSubscribers();
     _initPrimitives();
+    mCrashStorage.restore();
   }
 
   unLisp &getLisp()
@@ -60,6 +63,7 @@ public:
 
   void begin()
   {
+    mCrashStorage.printCrashDataIfExists();
     mNetworkDevice.begin();
   }
 
@@ -172,6 +176,8 @@ private:
   Button mLispButton;
 
   NetworkDevice mNetworkDevice;
+
+  CrashStorage mCrashStorage;
 
   TaskScheduler::TaskPtr mTaskMQTT;
   TaskScheduler::TaskPtr mTaskLispButton;

--- a/lib/AppKit/AppKit.h
+++ b/lib/AppKit/AppKit.h
@@ -40,15 +40,13 @@ public:
           auto arr = info.putArray("primitives");
           getLisp().serializeNamesOfPrimitives(arr.get());
           arr->closeArray();
-        })
-      , mLispButton(pinBtn, activeLevelBtn, 30), mNetworkDevice(credentials, pinBtn, activeLevelBtn, pinLed)
-      , mCrashStorage("crash_dump.txt")
+        }),
+        mLispButton(pinBtn, activeLevelBtn, 30), mNetworkDevice(credentials, pinBtn, activeLevelBtn, pinLed)
   {
     _initMqtt();
     _initTasks();
     _initSubscribers();
     _initPrimitives();
-    mCrashStorage.restore();
   }
 
   unLisp &getLisp()
@@ -63,7 +61,6 @@ public:
 
   void begin()
   {
-    mCrashStorage.printCrashDataIfExists();
     mNetworkDevice.begin();
   }
 
@@ -176,8 +173,6 @@ private:
   Button mLispButton;
 
   NetworkDevice mNetworkDevice;
-
-  CrashStorage mCrashStorage;
 
   TaskScheduler::TaskPtr mTaskMQTT;
   TaskScheduler::TaskPtr mTaskLispButton;

--- a/lib/Core/Storage/CrashStorage.cpp
+++ b/lib/Core/Storage/CrashStorage.cpp
@@ -16,29 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Uniot.h>
-#include <CrashStorage.h>
+#include <user_interface.h>
+#include "CrashStorage.h"
 
-uniot::TaskScheduler MainScheduler;
-uniot::GeneralBroker MainBroker;
-uniot::Credentials MyCredentials;
-
-
-void setup()
+namespace uniot
 {
-  auto taskHandleBroker = uniot::TaskScheduler::make(&MainBroker);
-  MainScheduler.push(taskHandleBroker);
-  taskHandleBroker->attach(100);
-
-  inject();
-}
-
-void loop()
+void uniotCrashCallback(struct rst_info *resetInfo, uint32_t stackStart, uint32_t stackEnd)
 {
-  MainScheduler.execute();
+  CrashStorage crashStorage("crash_dump.txt");
+  crashStorage.setCrashInfo(resetInfo, stackStart, stackEnd);
+  crashStorage.store();
 }
-
-extern "C" void custom_crash_callback(struct rst_info *resetInfo, uint32_t stackStart, uint32_t stackEnd)
-{
-  uniot::uniotCrashCallback(resetInfo, stackStart, stackEnd);
-}
+} // namespace uniot

--- a/lib/Core/Storage/CrashStorage.cpp
+++ b/lib/Core/Storage/CrashStorage.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <user_interface.h>
+#include <Logger.h>
 #include "CrashStorage.h"
 
 namespace uniot
@@ -26,5 +27,76 @@ void uniotCrashCallback(struct rst_info *resetInfo, uint32_t stackStart, uint32_
   CrashStorage crashStorage("crash_dump.txt");
   crashStorage.setCrashInfo(resetInfo, stackStart, stackEnd);
   crashStorage.store();
+}
+
+bool CrashStorage::store()
+{
+  mData = buildDumpData();
+  return Storage::store();
+}
+
+bool CrashStorage::clean()
+{
+  mResetInfo = nullptr;
+  mStackStart = 0;
+  mStackEnd = 0;
+
+  return Storage::clean();
+}
+
+bool CrashStorage::printCrashDataIfExists() const
+{
+  if (mData.size())
+  {
+    UNIOT_LOG_WARN("Crash file dump");
+    Serial.print(mData.c_str());
+    return true;
+  }
+  return false;
+}
+
+Bytes CrashStorage::buildDumpData() const
+{
+  const uint32_t crashTime = millis();
+
+  // // one complete log has 170 chars + (45 + 1) * n
+  // // n >= 2 e [2, 4, 6, ...]
+  // // 4220 + safety will last for 90 stack traces including header (170)
+  // // uint16_t maximumFileContent = 4250;
+
+  // maximum tmpBuffer size needed is 83, so 100 should be enough
+  const int16_t stackLength = mStackEnd - mStackStart;
+  char *tmpBuffer = (char *)calloc(170 + (45 + 1) * stackLength, sizeof(char));
+
+  // max. 65 chars of Crash time, reason, exception
+  int numBytesWritten = sprintf(tmpBuffer, "Crashed at %d ms\nRestart reason: %d\nException (%d):\n", crashTime, mResetInfo->reason, mResetInfo->exccause);
+
+  // 83 chars of epc1, epc2, epc3, excvaddr, depc info + 13 chars of >stack>
+  numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "epc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n>>>stack>>>\n", mResetInfo->epc1, mResetInfo->epc2, mResetInfo->epc3, mResetInfo->excvaddr, mResetInfo->depc);
+
+  uint32_t stackTrace = 0;
+
+  // collect stack trace
+  // one loop contains 45 chars of stack address, its content and '\n'
+  // e.g. "3fffffb0: feefeffe feefeffe 3ffe8508 40100459"
+  for (uint16_t i = 0; i < stackLength; i += 0x10)
+  {
+    numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "%08x: ", mStackStart + i);
+
+    for (uint8_t j = 0; j < 4; j++)
+    {
+      uint32_t *byteptr = (uint32_t *)(mStackStart + i + j * 4);
+      stackTrace = *byteptr;
+
+      numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "%08x ", stackTrace);
+    }
+    numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "\n");
+  }
+  // as we checked +15 char, this will always fit
+  numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "%s", "<<<stack<<<\n\n");
+
+  Bytes dumpData((const char *)tmpBuffer);
+  free(tmpBuffer);
+  return dumpData;
 }
 } // namespace uniot

--- a/lib/Core/Storage/CrashStorage.h
+++ b/lib/Core/Storage/CrashStorage.h
@@ -28,17 +28,13 @@ namespace uniot
 class CrashStorage : public Storage
   {
   public:
-    CrashStorage(const String &path) : Storage(path)
+    CrashStorage(const String &path)
+      : Storage(path)
     {
     }
 
-    virtual ~CrashStorage() {}
-
-    void setCrashInfo(struct rst_info* resetInfo, uint32_t stackStart, uint32_t stackEnd)
+    virtual ~CrashStorage()
     {
-      mResetInfo = resetInfo;
-      mStackStart = stackStart;
-      mStackEnd = stackEnd;
     }
 
     bool store()
@@ -47,7 +43,16 @@ class CrashStorage : public Storage
       return Storage::store();
     }
 
-    bool printCrashDataIfExists()
+    bool clean()
+    {
+      mResetInfo = nullptr;
+      mStackStart = 0;
+      mStackEnd = 0;
+
+      return Storage::clean();
+    }
+
+    bool printCrashDataIfExists() const
     {
       if (mData.size())
       {
@@ -58,16 +63,15 @@ class CrashStorage : public Storage
       return false;
     }
 
-    bool clean() {
-      mResetInfo = nullptr;
-      mStackStart = 0;
-      mStackEnd = 0;
-
-      return Storage::clean();
+  protected:
+    void setCrashInfo(struct rst_info* resetInfo, uint32_t stackStart, uint32_t stackEnd)
+    {
+      mResetInfo = resetInfo;
+      mStackStart = stackStart;
+      mStackEnd = stackEnd;
     }
 
-  protected:
-    Bytes buildDumpData()
+    Bytes buildDumpData() const
     {
       const uint32_t crashTime = millis();
 
@@ -111,6 +115,8 @@ class CrashStorage : public Storage
       return dumpData;
     }
 
+    friend void uniotCrashCallback(struct rst_info *resetInfo, uint32_t stackStart, uint32_t stackEnd);
+
     struct rst_info *mResetInfo;
     uint32_t mStackStart;
     uint32_t mStackEnd;
@@ -118,9 +124,3 @@ class CrashStorage : public Storage
 } // namespace uniot
 
 
-extern "C" void custom_crash_callback(struct rst_info * resetInfo, uint32_t stackStart, uint32_t stackEnd)
-{
-  uniot::CrashStorage crashStorage("crash_dump.txt");
-  crashStorage.setCrashInfo(resetInfo, stackStart, stackEnd);
-  crashStorage.store();
-}

--- a/lib/Core/Storage/CrashStorage.h
+++ b/lib/Core/Storage/CrashStorage.h
@@ -1,0 +1,126 @@
+/*
+ * This is a part of the Uniot project.
+ * Copyright (C) 2016-2020 Uniot <contact@uniot.io>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <Storage.h>
+
+#include <Arduino.h>
+#include <Logger.h>
+
+namespace uniot
+{
+class CrashStorage : public Storage
+  {
+  public:
+    CrashStorage(const String &path) : Storage(path)
+    {
+    }
+
+    virtual ~CrashStorage() {}
+
+    void setCrashInfo(struct rst_info* resetInfo, uint32_t stackStart, uint32_t stackEnd)
+    {
+      mResetInfo = resetInfo;
+      mStackStart = stackStart;
+      mStackEnd = stackEnd;
+    }
+
+    bool store()
+    {
+      mData = buildDumpData();
+      return Storage::store();
+    }
+
+    bool printCrashDataIfExists()
+    {
+      if (mData.size())
+      {
+        UNIOT_LOG_WARN("Crash file dump:");
+        Serial.print(mData.c_str());
+        return true;
+      }
+      return false;
+    }
+
+    bool clean() {
+      mResetInfo = nullptr;
+      mStackStart = 0;
+      mStackEnd = 0;
+
+      return Storage::clean();
+    }
+
+  protected:
+    Bytes buildDumpData()
+    {
+      const uint32_t crashTime = millis();
+
+      // // one complete log has 170 chars + 45 * n
+      // // n >= 2 e [2, 4, 6, ...]
+      // // 4220 + safety will last for 90 stack traces including header (170)
+      // // uint16_t maximumFileContent = 4250;
+
+      // maximum tmpBuffer size needed is 83, so 100 should be enough
+      const int16_t stackLength = mStackEnd - mStackStart;
+      char *tmpBuffer = (char*)calloc(170 + 45 * stackLength, sizeof(char));
+
+      // max. 65 chars of Crash time, reason, exception
+      int numBytesWritten = sprintf(tmpBuffer, "Crashed at %d ms\nRestart reason: %d\nException (%d):\n", crashTime, mResetInfo->reason, mResetInfo->exccause);
+
+      // 83 chars of epc1, epc2, epc3, excvaddr, depc info + 13 chars of >stack>
+      numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "epc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n>>>stack>>>\n", mResetInfo->epc1, mResetInfo->epc2, mResetInfo->epc3, mResetInfo->excvaddr, mResetInfo->depc);
+
+      uint32_t stackTrace = 0;
+
+      // collect stack trace
+      // one loop contains 45 chars of stack address and its content
+      // e.g. "3fffffb0: feefeffe feefeffe 3ffe8508 40100459"
+      for (uint16_t i = 0; i < stackLength; i += 0x10)
+      {
+        numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "%08x: ", mStackStart + i);
+
+        for (uint8_t j = 0; j < 4; j++)
+        {
+          uint32_t* byteptr = (uint32_t*) (mStackStart + i + j*4);
+          stackTrace = *byteptr;
+
+          numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "%08x ", stackTrace);
+        }
+      }
+      // as we checked +15 char, this will always fit
+      numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "%s", "<<<stack<<<\n\n");
+
+      Bytes dumpData((const char*)tmpBuffer);
+      free(tmpBuffer);
+      return dumpData;
+    }
+
+    struct rst_info *mResetInfo;
+    uint32_t mStackStart;
+    uint32_t mStackEnd;
+  };
+} // namespace uniot
+
+
+extern "C" void custom_crash_callback(struct rst_info * resetInfo, uint32_t stackStart, uint32_t stackEnd)
+{
+  uniot::CrashStorage crashStorage("crash_dump.txt");
+  crashStorage.setCrashInfo(resetInfo, stackStart, stackEnd);
+  crashStorage.store();
+}

--- a/lib/Core/Storage/CrashStorage.h
+++ b/lib/Core/Storage/CrashStorage.h
@@ -21,108 +21,41 @@
 #include <Storage.h>
 
 #include <Arduino.h>
-#include <Logger.h>
 
 namespace uniot
 {
 void uniotCrashCallback(struct rst_info *resetInfo, uint32_t stackStart, uint32_t stackEnd);
 
 class CrashStorage : public Storage
+{
+public:
+  CrashStorage(const String &path)
+    : Storage(path)
   {
+  }
+
+  virtual ~CrashStorage()
+  {
+  }
+
+  bool store();
+  bool clean();
+  bool printCrashDataIfExists() const;
+
+protected:
+  Bytes buildDumpData() const;
+
+  struct rst_info *mResetInfo;
+  uint32_t mStackStart;
+  uint32_t mStackEnd;
+
+private:
   friend void uniotCrashCallback(struct rst_info *resetInfo, uint32_t stackStart, uint32_t stackEnd);
-  public:
-    CrashStorage(const String &path)
-      : Storage(path)
-    {
-    }
-
-    virtual ~CrashStorage()
-    {
-    }
-
-    bool store()
-    {
-      mData = buildDumpData();
-      return Storage::store();
-    }
-
-    bool clean()
-    {
-      mResetInfo = nullptr;
-      mStackStart = 0;
-      mStackEnd = 0;
-
-      return Storage::clean();
-    }
-
-    bool printCrashDataIfExists() const
-    {
-      if (mData.size())
-      {
-        UNIOT_LOG_WARN("Crash file dump");
-        Serial.print(mData.c_str());
-        return true;
-      }
-      return false;
-    }
-
-  protected:
-    void setCrashInfo(struct rst_info* resetInfo, uint32_t stackStart, uint32_t stackEnd)
-    {
-      mResetInfo = resetInfo;
-      mStackStart = stackStart;
-      mStackEnd = stackEnd;
-    }
-
-    Bytes buildDumpData() const
-    {
-      const uint32_t crashTime = millis();
-
-      // // one complete log has 170 chars + (45 + 1) * n
-      // // n >= 2 e [2, 4, 6, ...]
-      // // 4220 + safety will last for 90 stack traces including header (170)
-      // // uint16_t maximumFileContent = 4250;
-
-      // maximum tmpBuffer size needed is 83, so 100 should be enough
-      const int16_t stackLength = mStackEnd - mStackStart;
-      char *tmpBuffer = (char*)calloc(170 + (45 + 1) * stackLength, sizeof(char));
-
-      // max. 65 chars of Crash time, reason, exception
-      int numBytesWritten = sprintf(tmpBuffer, "Crashed at %d ms\nRestart reason: %d\nException (%d):\n", crashTime, mResetInfo->reason, mResetInfo->exccause);
-
-      // 83 chars of epc1, epc2, epc3, excvaddr, depc info + 13 chars of >stack>
-      numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "epc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n>>>stack>>>\n", mResetInfo->epc1, mResetInfo->epc2, mResetInfo->epc3, mResetInfo->excvaddr, mResetInfo->depc);
-
-      uint32_t stackTrace = 0;
-
-      // collect stack trace
-      // one loop contains 45 chars of stack address, its content and '\n'
-      // e.g. "3fffffb0: feefeffe feefeffe 3ffe8508 40100459"
-      for (uint16_t i = 0; i < stackLength; i += 0x10)
-      {
-        numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "%08x: ", mStackStart + i);
-
-        for (uint8_t j = 0; j < 4; j++)
-        {
-          uint32_t* byteptr = (uint32_t*) (mStackStart + i + j*4);
-          stackTrace = *byteptr;
-
-          numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "%08x ", stackTrace);
-        }
-        numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "\n");
-      }
-      // as we checked +15 char, this will always fit
-      numBytesWritten += sprintf(tmpBuffer + numBytesWritten, "%s", "<<<stack<<<\n\n");
-
-      Bytes dumpData((const char*)tmpBuffer);
-      free(tmpBuffer);
-      return dumpData;
-    }
-
-    struct rst_info *mResetInfo;
-    uint32_t mStackStart;
-    uint32_t mStackEnd;
-  };
+  void setCrashInfo(struct rst_info* resetInfo, uint32_t stackStart, uint32_t stackEnd)
+  {
+    mResetInfo = resetInfo;
+    mStackStart = stackStart;
+    mStackEnd = stackEnd;
+  }
+};
 } // namespace uniot
-
-

--- a/lib/Core/Storage/Storage.h
+++ b/lib/Core/Storage/Storage.h
@@ -74,7 +74,7 @@ public:
     file.close();
     // using SPIFFS.gc() can avoid or reduce issues where SPIFFS reports
     // free space but is unable to write additional data to a file
-    UNIOT_LOG_WARN_IF(!SPIFFS.gc(), "SPIFFS gc failed. Caller: %s", mPath.c_str());
+    UNIOT_LOG_DEBUG_IF(!SPIFFS.gc(), "SPIFFS gc failed. Caller: %s", mPath.c_str());
     return true;
   }
 

--- a/lib/Uniot/Uniot.cpp
+++ b/lib/Uniot/Uniot.cpp
@@ -17,10 +17,12 @@
  */
 
 #include <Uniot.h>
+#include <CrashStorage.h>
 
 uniot::TaskScheduler MainScheduler;
 uniot::GeneralBroker MainBroker;
 uniot::Credentials MyCredentials;
+
 
 void setup()
 {
@@ -34,4 +36,19 @@ void setup()
 void loop()
 {
   MainScheduler.execute();
+}
+
+namespace uniot
+{
+void uniotCrashCallback(struct rst_info *resetInfo, uint32_t stackStart, uint32_t stackEnd)
+{
+  CrashStorage crashStorage("crash_dump.txt");
+  crashStorage.setCrashInfo(resetInfo, stackStart, stackEnd);
+  crashStorage.store();
+}
+}
+
+extern "C" void custom_crash_callback(struct rst_info *resetInfo, uint32_t stackStart, uint32_t stackEnd)
+{
+  uniot::uniotCrashCallback(resetInfo, stackStart, stackEnd);
 }


### PR DESCRIPTION
(#9) Added possibility to save exception details and stack trace to file every time ESP device crashes.
After the next restart, the content of that file will be printed over the Serial port interface.